### PR TITLE
precreate tensor X to fix the issue of abnormally high CUDA memory usage in inference process with the MDX23C model

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -132,32 +132,21 @@ def demix_base_mdxv3(config, model, mix, device):
         mix = torch.cat([torch.zeros(2, C - H), mix, torch.zeros(2, pad_size + C - H)], 1)
         mix = mix.to(device)
 
-        chunks = []
-        i = 0
-        while i + C <= mix.shape[1]:
-            chunks.append(mix[:, i:i + C])
-            i += H
-        chunks = torch.stack(chunks)
+        chunks = mix.unfold(1, C, H).transpose(0, 1)
 
-        batches = []
-        i = 0
-        while i < len(chunks):
-            batches.append(chunks[i:i + batch_size])
-            i = i + batch_size
+        batches = [chunks[i : i + batch_size] for i in range(0, len(chunks), batch_size)]
 
-        X = torch.zeros(S, 2, C - H) if S > 1 else torch.zeros(2, C - H)
-        X = X.to(device)
+        X = torch.zeros(2, *mix.shape).to(device)
 
         with torch.cuda.amp.autocast():
             with torch.no_grad():
+                cnt = 0
                 for batch in tqdm(batches, ncols=60):
                     # self.running_inference_progress_bar(len(batches))
                     x = model(batch)
                     for w in x:
-                        a = X[..., :-(C - H)]
-                        b = X[..., -(C - H):] + w[..., :(C - H)]
-                        c = w[..., (C - H):]
-                        X = torch.cat([a, b, c], -1)
+                        X[..., cnt * H : cnt * H + C] += w
+                        cnt += 1
 
         estimated_sources = X[..., C - H:-(pad_size + C - H)] / N
         


### PR DESCRIPTION
With the original script, CUDA memory experienced a periodic high-occupation and low-occupation process. This unsteady behavior slowed down the inference speed, and made processing long audio almost impossible. 

With a RTX4090 GPU, the inference speed is ~27it/s :

![image](https://github.com/jarredou/MVSEP-MDX23-Colab_v2/assets/144443371/f78b3890-6ae2-401e-9706-f6d9d6c13ada)

However, as the memory usage increases during inference, the speed decreases significantly:

![image](https://github.com/jarredou/MVSEP-MDX23-Colab_v2/assets/144443371/f85bef13-7bd9-401e-9175-44873c5dd439)

**I changed the implementation of chunk's fold and unfold**. By precreate tensor X, It is now possible to process long audio with a low and steady memory usage.

Here is a one-hour-long audio example.

Before:

![image](https://github.com/jarredou/MVSEP-MDX23-Colab_v2/assets/144443371/8733e44c-6a75-46f3-b8a0-116465b2acf1)

After:

![image](https://github.com/jarredou/MVSEP-MDX23-Colab_v2/assets/144443371/fc274501-a00b-429e-a60c-2ea46538a0dd)

**Attention please:** Though almost the same, after my modification the resulting audio file have minor difference：

![image](https://github.com/jarredou/MVSEP-MDX23-Colab_v2/assets/144443371/7a7b18ed-6746-4f4e-aba2-fc0b10d0c825)

Currently I have not made clear the reason, but feel free to test this PR and feed information



